### PR TITLE
Only hash embed urls if `output.hashed` is true.

### DIFF
--- a/assetgen/__init__.py
+++ b/assetgen/__init__.py
@@ -228,7 +228,7 @@ class CSSAsset(Asset):
         return self.cache.setdefault(path, (data, 1))
 
     def get_embed_url(self, path, data=None):
-        if data is None:
+        if data is None or not self.runner.hashed:
             digest = ''
         else:
             digest = sha1(data).hexdigest() + '-'


### PR DESCRIPTION
Currently, embed urls always add a hash to the file url, even when `output.hashed` is `false`.  This results in urls that don't work, as the gfx resource files are emitted without a hash in the filename.
