### PR TITLE
Update generators (if necessary) prior to running them

### DIFF
--- a/assetgen/main.py
+++ b/assetgen/main.py
@@ -1173,12 +1173,12 @@ def main(argv=None):
             try:
                 for assetgen in generators:
                     assetgen.run()
+                sleep(1)
                 for idx, file in enumerate(files):
                     mtime = stat(file)[ST_MTIME]
                     if mtime > mtime_cache[file]:
                         mtime_cache[file] = mtime
                         generators[idx] = AssetGenRunner(file, profile, force)
-                sleep(1)
             except AppExit:
                 sleep(3)
             except KeyboardInterrupt:


### PR DESCRIPTION
Modifications to the assetgen.yaml should be taken into account before running the generators, just in case someone modified several files at once, including assetgen.yaml.  This can happen in IDEs that support "Save All" and in source control operations where a large number of files may be updated at once.   In this case you may find that the change to assetgen.yaml doesn't include newly added files or includes deleted files because it is using an older version of assetgen.yaml than expected.