### PR TITLE
When hashes are on, use SHA1 hashes to decide if a file needs to be upda...

### DIFF
--- a/assetgen/main.py
+++ b/assetgen/main.py
@@ -387,8 +387,8 @@ class CSSAsset(Asset):
         try:
             data = open(filepath, 'rb').read()
         except IOError:
-            log.error("!! Couldn't find %s for %s" % (
-                filepath, self.path
+            log.error("!! Couldn't find %r for %r in %r" % (
+                filepath, self.path, self.embed_path_root
                 ))
             return self.cache.setdefault(
                 path,
@@ -1081,6 +1081,7 @@ class AssetGenRunner(object):
             directory, filename = split(key)
             digest, output_path = self.apply_hash(directory, filename, depends)
             if output_path not in paths:
+                self.output_data.pop(key)
                 log.debug('%r not fresh, hash has changed (new filename is %r)', key, output_path)
                 return False
         else:


### PR DESCRIPTION
The hash is now computed from the hashes of its input files instead of from the output file contents, which means it only changes when the input files change.  When trying to decide whether to update a file we can check whether its computed filename differs from its previously saved filename in the json file.  This is nicer than timestamps because sometimes as a result of VCS operations or just doing things in the wrong order the timestamps are not in the right order.  Also, if files are added or remove from the inputs for a file, this will detect that and rebuild.  The timestamp approach cannot detect a change to the list of inputs.